### PR TITLE
Ignore C compiler warning

### DIFF
--- a/cgo_src/excelizer.go
+++ b/cgo_src/excelizer.go
@@ -6,6 +6,10 @@ package main
 
 typedef const ERL_NIF_TERM nif_arg_t;
 
+#if defined(__clang__)
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-function"
 static void update_binary(ErlNifBinary* bin, void* str, size_t size) {
 	memcpy(bin->data, str, size);
 }
@@ -13,6 +17,22 @@ static void update_binary(ErlNifBinary* bin, void* str, size_t size) {
 static ERL_NIF_TERM get_arg(ERL_NIF_TERM* arg, int index) {
 	return arg[index];
 }
+#pragma clang diagnostic pop
+
+#elif defined(__GNUC__)
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+static void update_binary(ErlNifBinary* bin, void* str, size_t size) {
+	memcpy(bin->data, str, size);
+}
+
+static ERL_NIF_TERM get_arg(ERL_NIF_TERM* arg, int index) {
+	return arg[index];
+}
+#pragma GCC diagnostic pop
+
+#endif
 
 */
 import "C"


### PR DESCRIPTION
Currently, when we run `make`, the below warnings are shown.
```
mkdir -p priv && cd cgo_src && make clean && make excelizer_nif.so && cd .. && cp cgo_src/excelizer_nif.so priv
rm -rf excelizer_nif.so libgo_excelizer.h libgo_excelizer.a
CC="gcc-9" CGO_CFLAGS="-Wall -I/usr/local/Cellar/erlang/23.0.4/lib/erlang/erts-11.0.4/include -finline-functions -fPIC" CGO_LDFLAGS="-L/usr/local/Cellar/erlang/23.0.4/lib/erlang/erts-11.0.4/lib -flat_namespace -undefined suppress" go build -v -buildmode=c-archive -o libgo_excelizer.a excelizer.go
runtime/cgo
net
command-line-arguments
# command-line-arguments
In file included from _cgo_export.c:4:
excelizer.go:13:21: warning: 'get_arg' defined but not used [-Wunused-function]
excelizer.go:9:13: warning: 'update_binary' defined but not used [-Wunused-function]
CC="gcc-9" cc -Wall -I/usr/local/Cellar/erlang/23.0.4/lib/erlang/erts-11.0.4/include -finline-functions -fPIC -shared -L/usr/local/Cellar/erlang/23.0.4/lib/erlang/erts-11.0.4/lib -flat_namespace -undefined suppress excelizer.c libgo_excelizer.a -o excelizer_nif.so
In file included from excelizer.c:4:
excelizer.go:9:13: warning: unused function 'update_binary' [-Wunused-function]
static void update_binary(ErlNifBinary* bin, void* str, size_t size) {
            ^
excelizer.go:13:21: warning: unused function 'get_arg' [-Wunused-function]
static ERL_NIF_TERM get_arg(ERL_NIF_TERM* arg, int index) {
                    ^
2 warnings generated.
```

These functions are used in `cgo_src/excelizer.go`, so I've ignored these warning.